### PR TITLE
[feat]: v1.0.1 업데이트

### DIFF
--- a/AVIRO.xcodeproj/project.pbxproj
+++ b/AVIRO.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		C5ED46952AAEB3F300F2DA04 /* OperationHourView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ED46942AAEB3F300F2DA04 /* OperationHourView.swift */; };
 		C5ED46982AAEEFB600F2DA04 /* OperationHoursView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ED46972AAEEFB600F2DA04 /* OperationHoursView.swift */; };
 		C5F1014F2A6D19A800C53286 /* VeganOptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1014E2A6D19A800C53286 /* VeganOptionButton.swift */; };
+		C5F33DFD2ADED19000A29FB9 /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F33DFC2ADED19000A29FB9 /* System.swift */; };
 		C5FA0EAA2A94DB3E004AD8B4 /* ReportReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FA0EA92A94DB3E004AD8B4 /* ReportReviewViewController.swift */; };
 		C5FA0EAC2A94DF39004AD8B4 /* ReportReviewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FA0EAB2A94DF39004AD8B4 /* ReportReviewPresenter.swift */; };
 		C5FD92E32A9C6C1E00CF4673 /* EditLocationAddressTextTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FD92E22A9C6C1E00CF4673 /* EditLocationAddressTextTableViewCell.swift */; };
@@ -401,6 +402,7 @@
 		C5ED46942AAEB3F300F2DA04 /* OperationHourView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationHourView.swift; sourceTree = "<group>"; };
 		C5ED46972AAEEFB600F2DA04 /* OperationHoursView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationHoursView.swift; sourceTree = "<group>"; };
 		C5F1014E2A6D19A800C53286 /* VeganOptionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VeganOptionButton.swift; sourceTree = "<group>"; };
+		C5F33DFC2ADED19000A29FB9 /* System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = System.swift; sourceTree = "<group>"; };
 		C5FA0EA92A94DB3E004AD8B4 /* ReportReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportReviewViewController.swift; sourceTree = "<group>"; };
 		C5FA0EAB2A94DF39004AD8B4 /* ReportReviewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportReviewPresenter.swift; sourceTree = "<group>"; };
 		C5FD92E22A9C6C1E00CF4673 /* EditLocationAddressTextTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLocationAddressTextTableViewCell.swift; sourceTree = "<group>"; };
@@ -955,6 +957,7 @@
 				C5803F5C2A88C3C00064A853 /* LocationUtility.swift */,
 				C5A201B12A98502500A54381 /* TimeUtility.swift */,
 				C5C20BAB2AD504D500855BBB /* AmplitudeUtility.swift */,
+				C5F33DFC2ADED19000A29FB9 /* System.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -1657,6 +1660,7 @@
 				C51000382AB5F3BD00F65C1F /* UIFont+Extension.swift in Sources */,
 				C5FA0EAA2A94DB3E004AD8B4 /* ReportReviewViewController.swift in Sources */,
 				C5C90EBD2AA85E7000AB3668 /* AVIROOperationHours+DTO.swift in Sources */,
+				C5F33DFD2ADED19000A29FB9 /* System.swift in Sources */,
 				C513854E2AAD8E9F001AB827 /* AVIROReportPlace+DTO.swift in Sources */,
 				C520663C2A80C0450038ECCD /* CenterCoordinate.swift in Sources */,
 				C58EC7D22AB1B5AD00401FF7 /* AVIROEditPhone+DTO.swift in Sources */,
@@ -1964,7 +1968,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = SeonghunJeon.VeganRestaurant;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1999,7 +2003,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = SeonghunJeon.VeganRestaurant;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/AVIRO/Custom/Utility/System.swift
+++ b/AVIRO/Custom/Utility/System.swift
@@ -1,0 +1,37 @@
+//
+//  System.swift
+//  AVIRO
+//
+//  Created by 전성훈 on 2023/10/17.
+//
+
+import UIKit
+
+struct System {
+    static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    static let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    
+    static let appStoreOpenUrlString = "itms-apps://itunes.apple.com/app/apple-store/\(APP.appId.rawValue)"
+    
+    func latestVersion() -> String? {
+        guard let url = URL(string: "http://itunes.apple.com/lookup?id=\(APP.appId.rawValue)"),
+              let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(
+                with: data,
+                options: .allowFragments
+              ) as? [String: Any],
+              let results = json["results"] as? [[String: Any]],
+              let appStoreVersion = results[0]["version"] as? String else {
+            return nil
+        }
+        
+        return appStoreVersion
+    }
+    
+    func openAppStore() {
+        guard let url = URL(string: System.appStoreOpenUrlString) else { return }
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+}

--- a/AVIRO/Model/LocalDataModel/MarkerModelCache.swift
+++ b/AVIRO/Model/LocalDataModel/MarkerModelCache.swift
@@ -64,15 +64,17 @@ final class MarkerModelCache: MarkerModelCacheProtocol {
             var updateMarker = markerModel
             
             DispatchQueue.main.async { [weak self] in
+                self?.markers[index].marker.position = updateMarker.marker.position
+                
                 self?.markers[index].marker.changeIcon(
                     updateMarker.mapPlace,
                     updateMarker.isClicked
                 )
+                                
+                updateMarker.marker = (self?.markers[index].marker)!
+                
+                self?.markers[index] = updateMarker
             }
-            
-            updateMarker.marker = markers[index].marker
-            
-            markers[index] = updateMarker
         } else {
             markers.append(markerModel)
             updatedMarkers.append(markerModel.marker)

--- a/AVIRO/Scene/Presenter/Home/EditPresenter/ChangeableAddressPresenter/ChangeableAddressPresenter.swift
+++ b/AVIRO/Scene/Presenter/Home/EditPresenter/ChangeableAddressPresenter/ChangeableAddressPresenter.swift
@@ -37,8 +37,10 @@ final class ChangeableAddressPresenter {
     private var placeMarkerModel: MarkerModel?
     
     private var changedAddress: String?
+    private var changedLocation = NMGLatLng()
         
     var afterChangedAddress: ((String?) -> Void)?
+    var afterChangedAddressWhenMapView: ((String?, NMGLatLng) -> Void)?
     
     var addressModelCount: Int {
         return addressModels.count
@@ -122,6 +124,8 @@ final class ChangeableAddressPresenter {
     }
     
     func whenAfterChangedCoordinate(_ coordinate: NMGLatLng) {
+        self.changedLocation = coordinate
+        
         let lat = String(coordinate.lat)
         let lng = String(coordinate.lng)
         
@@ -146,6 +150,11 @@ final class ChangeableAddressPresenter {
     
     func editAddress() {
         self.afterChangedAddress?(changedAddress)        
+        viewController?.popViewController()
+    }
+    
+    func editAddressWhenMapView() {
+        self.afterChangedAddressWhenMapView?(changedAddress, changedLocation)
         viewController?.popViewController()
     }
     

--- a/AVIRO/Scene/View/TabBar/Home/Edit/EditPlaceInfo/EditPlaceInfoSubView/ChangeableAddressViewController/ChangeableAddressViewController.swift
+++ b/AVIRO/Scene/View/TabBar/Home/Edit/EditPlaceInfo/EditPlaceInfoSubView/ChangeableAddressViewController/ChangeableAddressViewController.swift
@@ -63,7 +63,7 @@ final class ChangeableAddressViewController: UIViewController {
         }
         
         view.isTappedEditButtonWhemMapView = { [weak self] in
-            self?.presenter.editAddress()
+            self?.presenter.editAddressWhenMapView()
         }
         
         return view

--- a/AVIRO/Scene/View/TabBar/Home/Edit/EditPlaceInfo/EditPlaceInfoSubView/EditLocationBottomView.swift
+++ b/AVIRO/Scene/View/TabBar/Home/Edit/EditPlaceInfo/EditPlaceInfoSubView/EditLocationBottomView.swift
@@ -153,7 +153,7 @@ final class EditLocationBottomView: UIView {
         marker.mapView = naverMap
         
         let latLng = marker.position
-        let position = NMFCameraPosition(latLng, zoom: 17)
+        let position = NMFCameraPosition(latLng, zoom: 18)
         let cameraUpdate = NMFCameraUpdate(position: position)
         
         naverMap.moveCamera(cameraUpdate)
@@ -173,7 +173,7 @@ final class EditLocationBottomView: UIView {
     }
     
     func changedNaverMap(_ latLng: NMGLatLng) {
-        let position = NMFCameraPosition(latLng, zoom: 17)
+        let position = NMFCameraPosition(latLng, zoom: 18)
         let cameraUpdate = NMFCameraUpdate(position: position)
         
         naverMap.moveCamera(cameraUpdate)

--- a/AVIRO/Scene/View/TabBar/Home/Edit/EditPlaceInfo/EditPlaceInfoViewController.swift
+++ b/AVIRO/Scene/View/TabBar/Home/Edit/EditPlaceInfo/EditPlaceInfoViewController.swift
@@ -481,6 +481,15 @@ extension EditPlaceInfoViewController: EditPlaceInfoProtocol {
         presenter.afterChangedAddress = { [weak self] address in
             guard let address = address else { return }
             
+            self?.presenter.isChangedFromPublicAddress = true
+            self?.editLocationBottomView.changedAddressLabel(address)
+        }
+        
+        presenter.afterChangedAddressWhenMapView = { [weak self] (address, coordinate) in
+            guard let address = address else { return }
+            
+            self?.presenter.isChangedFromPublicAddress = false
+            self?.presenter.locationFromMapView = coordinate
             self?.editLocationBottomView.changedAddressLabel(address)
         }
         

--- a/AVIRO/Scene/View/TabBar/MyPage/SubView/SettingCell.swift
+++ b/AVIRO/Scene/View/TabBar/MyPage/SubView/SettingCell.swift
@@ -97,7 +97,7 @@ final class SettingCell: UITableViewCell {
 //        if settingsRow == .displayMode {
 //            pushButton.isHidden = false
 //        }
-//        
+        
         if settingsRow == .versionInfo {
             versionLabel.isHidden = false
         }
@@ -115,41 +115,13 @@ final class SettingCell: UITableViewCell {
     }
     
     private func loadVersion() {
-        var currentVersion = ""
-        var latestVersion = ""
-        
-        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-            currentVersion = version
-        }
-        
-        let appID = APP.appId.rawValue
-        let url = URL(string: "https://itunes.apple.com/lookup?id=\(appID)")!
-
-        let task = URLSession.shared.dataTask(with: url) { (data, _, _) in
-            defer {
-                DispatchQueue.main.async { [weak self] in
-                    self?.versionLabel.text = "현재 " + currentVersion + " / " + "최신 " + latestVersion
-                }
-            }
-            guard let data = data else {
-                latestVersion = "1.0"
-                return
-            }
+        DispatchQueue.global().async { [weak self] in
+            let latestVersion = System().latestVersion() ?? "0.0"
+            let currentVersion = System.appVersion ?? "0.0"
             
-            do {
-                if let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
-                   let results = json["results"] as? [[String: Any]],
-                   let appInfo = results.first,
-                   let version = appInfo["version"] as? String {
-                    latestVersion = version
-                } else {
-                    latestVersion = "1.0"
-                }
-            } catch {
-                latestVersion = "1.0"
+            DispatchQueue.main.async {
+                self?.versionLabel.text = "현재" + currentVersion + " / " + "최신 " + latestVersion
             }
         }
-
-        task.resume()
     }
 }

--- a/AVIRO/Utils/LaunchScreenViewController.swift
+++ b/AVIRO/Utils/LaunchScreenViewController.swift
@@ -60,13 +60,15 @@ final class LaunchScreenViewController: UIViewController {
     }()
     
     private lazy var animationView: LottieAnimationView = {
-        let test = LottieAnimationView(name: "Berry2")
+        let lottie = LottieAnimationView(name: "Berry2")
         
-        test.play()
-        test.loopMode = .loop
+        lottie.play()
+        lottie.loopMode = .loop
         
-        return test
+        return lottie
     }()
+    
+    var isUpdateAlertShown: Bool = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -98,14 +100,50 @@ final class LaunchScreenViewController: UIViewController {
         ])
         
         if UIScreen.main.bounds.height < 812.0 {
-                NSLayoutConstraint.activate([
-                    bgImageView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 100)
-                ])
-            } else {
-                // 그 외 모델일 때의 제약 조건 설정
-                NSLayoutConstraint.activate([
-                    bgImageView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
-                ])
+            NSLayoutConstraint.activate([
+                bgImageView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 100)
+            ])
+        } else {
+            // 그 외 모델일 때의 제약 조건 설정
+            NSLayoutConstraint.activate([
+                bgImageView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+            ])
+        }
+        
+        checkVersion()
+    }
+    
+    private func checkVersion() {
+        DispatchQueue.global().async { [weak self] in
+            let latestVersion = System().latestVersion() ?? "0.0"
+            let currentVersion = System.appVersion ?? "0.0"
+            
+            let splitLatestVersion = latestVersion.split(separator: ".").map { $0 }
+            let splitCurrentVersion = currentVersion.split(separator: ".").map { $0 }
+                
+            DispatchQueue.main.async {
+                if splitCurrentVersion[0] < splitLatestVersion[0] {
+                    self?.showUpdateAlert(latestVersion)
+                } else {
+                    if splitCurrentVersion[1] < splitLatestVersion[1] {
+                        self?.showUpdateAlert(latestVersion)
+                    }
+                }
             }
+        }
+    }
+    
+    private func showUpdateAlert(_ latestVersion: String) {
+        isUpdateAlertShown = true
+        
+        let action: AlertAction = (title: "업데이트", style: .default, handler: {
+            System().openAppStore()
+        })
+        
+        showAlert(
+            title: "업데이트 알림",
+            message: "어비로의 새로운 버전이 있습니다! \(latestVersion) 버전으로 업데이트 해주세요.",
+            actions: [action]
+        )
     }
 }

--- a/AVIRO/Utils/SceneDelegate.swift
+++ b/AVIRO/Utils/SceneDelegate.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
+    
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions
@@ -23,9 +23,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         self.window?.rootViewController = LaunchScreenViewController()
         self.window?.makeKeyAndVisible()
-         
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-             AppController.shared.show(in: window)
-         }
+            if let vc = self.window?.rootViewController as? LaunchScreenViewController, !vc.isUpdateAlertShown {
+                AppController.shared.show(in: window)
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 │   └── Utility
 │       ├── AmplitudeUtility.swift
 │       ├── LocationUtility.swift
+│       ├── System.swift
 │       └── TimeUtility.swift
 ├── Manager
 │   ├── APIManager
@@ -160,8 +161,9 @@
 │   │   └── ReportModel
 │   │       └── ReportReviewModel.swift
 │   ├── LocalDataModel
-│   │   ├── LocalBookmarkData.swift
-│   │   └── LocalMarkerData.swift
+│   │   ├── BookmarkCache.swift
+│   │   ├── MarkerModelCache.swift
+│   │   └── MarkerModelLocalDB.swift
 │   ├── MyPageModel
 │   │   └── MyDataModel.swift
 │   ├── PlaceListModel


### PR DESCRIPTION
기능 향상
: 최초 서버 연동 후 식당 데이터를 로컬에 저장해서 사용자의 데이터 사용량을 줄였습니다!
: 마커 클릭 간 강제 줌레벨 변경되던 기능을 삭제했습니다! 
: 메뉴 등록 및 수정 간 작성하기 더욱더 쉽도록 조치했습니다! 
: 가게 등록 간 비건 <-> 요청 메뉴 이동시 데이터가 이제 삭제가 되지 않습니다!
: 마커 미세조정이 가능해졌습니다!
: 핸드폰 RAM 부족 시 네이버 지도 lite모드 변경 기능 추가했습니다!
버그 수정
: 정보 수정 요청 간 에러 메시지 확인 후 해당 페이지의 터치가 안되는 문제 수정했습니다! 
: 홈페이지 업데이트 실패 버그 수정했습니다! 
: 주소 변경 후 튕김 버그 수정했습니다! 
: 검색 간 간헐적 에러 메시지 팝업 버그 수정했습니다! 
: 동일 위치 마커 클릭 불가 문제 수정했습니다!
내부
: 이제 업데이트 정보에따라 강제 / 비강제 업데이트 기능 추가했습니다. 해당 화면은 사용자 버전 확인 후 
1,2번째 자리가 낮을 경우 강제 업데이트 알람 팝업됩니다. 